### PR TITLE
Account Info Form No Attrs Error Fix

### DIFF
--- a/yikes-inc-custom-login.php
+++ b/yikes-inc-custom-login.php
@@ -687,6 +687,12 @@ class YIKES_Custom_Login {
 				$errors[] = $this->get_error_message( $code );
 			}
 		}
+
+		// Checking to see if shortcode has any props
+		if ( ! is_array( $attributes ) ) {
+			$attributes = array();
+		}
+
 		$attributes['errors'] = $errors;
 		// Render the login form using an external template
 		return $this->get_template_html( 'account-info-form', $attributes );


### PR DESCRIPTION
The `[account-form]` shortcode has a little bug when no attributes are passed. 

When rendering the form we check for errors and if there are errors we add them to the attributes. However, if no attributes are passed this will have a type of string. 

- When we try to add errors to this string as if it were an array we receive an error. 
- When adding array type check to $attributes argument this returned a type error as we were receiving a string.

To fix this I'm simply checking if $attributes is_array() and if not assigning it to an array literal.

Closes #11 

