### PR TITLE
Fix custom template reference errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A WordPress plugin that replaces the login flow with custom pages.
 
 ### Custom Templates:
 
-Users can override the default templates by copying `wp-content/plugins/custom-wp-login/templates/` into the theme root, and renaming the directory `/custom-wp-login/`. You can remove any of the templates you don't need, and customize the ones you will be using.
+Users can override the default templates by copying `wp-content/plugins/custom-wp-login/templates/` into the theme root, and renaming the directory to `/yikes-custom-login/`. You can remove any of the templates you don't need, and customize the ones you will be using.
 
 ### Additional Profile Fields
 

--- a/lib/classes/email-templates.php
+++ b/lib/classes/email-templates.php
@@ -28,9 +28,9 @@ class YIKES_Email_Templates {
 	 * @return string                     HTML markup for the email to be sent
 	 */
 	public function send_password_reset_email( $key, $user_login, $reset_pass_url ) {
-		if ( file_exists( get_stylesheet_directory() . '/yikes-inc-custom-login/templates/email/password-reset.php' ) ) {
+		if ( file_exists( get_template_directory() . '/yikes-custom-login/email/password-reset.php' ) ) {
 			// include the password reset email
-			include_once( get_stylesheet_directory() . '/yikes-inc-custom-login/templates/email/password-reset.php' );
+			include_once( get_template_directory() . '/yikes-custom-login/email/password-reset.php' );
 			return;
 		}
 		// include the password reset email
@@ -84,8 +84,8 @@ class YIKES_Email_Templates {
 		// Inclde our custom 'Welcome' email template
 		ob_start();
 		// Include the welcome email
-		if ( file_exists( get_stylesheet_directory_uri() . '/yikes-inc-custom-login/templates/email/welcome.php' ) ) {
-			include_once( get_stylesheet_directory_uri() . '/yikes-inc-custom-login/templates/email/welcome.php' );
+		if ( file_exists( get_template_directory() . '/yikes-custom-login/email/welcome.php' ) ) {
+			include_once( get_template_directory() . '/yikes-custom-login/email/welcome.php' );
 		} else {
 			include_once( YIKES_CUSTOM_LOGIN_PATH . 'templates/email/welcome.php' );
 		}

--- a/lib/classes/email-templates.php
+++ b/lib/classes/email-templates.php
@@ -28,9 +28,9 @@ class YIKES_Email_Templates {
 	 * @return string                     HTML markup for the email to be sent
 	 */
 	public function send_password_reset_email( $key, $user_login, $reset_pass_url ) {
-		if ( file_exists( get_stylesheet_directory_uri() . '/yikes-inc-custom-login/templates/email/password-reset.php' ) ) {
+		if ( file_exists( get_stylesheet_directory() . '/yikes-inc-custom-login/templates/email/password-reset.php' ) ) {
 			// include the password reset email
-			include_once( get_stylesheet_directory_uri() . '/yikes-inc-custom-login/templates/email/password-reset.php' );
+			include_once( get_stylesheet_directory() . '/yikes-inc-custom-login/templates/email/password-reset.php' );
 			return;
 		}
 		// include the password reset email


### PR DESCRIPTION
There is an inconsistency between the custom template search folder for emails and for page templates. As it seems that the custom emails could not be found previously, I have adapted their path to the same path as the page templates. Additionally, the readme reference to the custom folder was not consistent with the code.